### PR TITLE
Add profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# .github
-SPDX Overview
+# SPDX github Organization
+
+This repo configures the SPDX Github Organization https://github.com/spdx

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,60 @@
+# System Package Data Exchange (SPDX)
+
+Main Website: https://spdx.dev/
+
+This organization houses the primary development activity for SPDX. Use the
+categories below to find the repositories you are interested in.
+
+## Learning about SPDX SBoM and Examples
+
+These repositories are useful if you are looking for more information about how
+to use SPDX and example SPDX files.
+
+ * [using](./using) - This repository contains long-form text that explains how
+   to use SPDX, or walks readers through various SPDX use cases.
+ * [spdx-examples](./spdx-examples) - This repository contains example SPDX
+   files covering various versions and use cases
+
+
+## SPDX SBoM Tooling
+
+These repository contain SPDX related tools and code bindings, which are useful
+if you want to produce or consumer SPDX documents.
+
+ * [tools-python](./tools-python) - Python library for dealing with SPDX
+   documents
+ * [tools-golang](./tools-golang) - Go library for dealing with SPDX documents
+ * [tools-java](./tools-java) - Java library for dealing with SPDX documents
+ * [spdx-python-model](./spdx-python-model) - Low level Python library for
+   reading and writing SPDX documents
+ * [spdx-go-model](./spdx-go-model) - Low level Go library for reading and
+   writing SPDX documents
+
+## SPDX Licenses
+
+These repositories are related to the SPDX License List
+
+ * [license-list-XML](./license-list-XML) - The XML Source for the SPDX License List
+ * [license-list-data](./license-list-data) - The generated content (e.g. Web
+   site, JSON, etc) from the License List XML
+
+## SPDX 3 SBoM Model
+
+These repositories define the SPDX 3 SBoM Standard
+
+ * [spdx-3-model](./spdx-3-model) - This is the main SPDX 3 model files. If you
+   would like to modify or extend the SPDX 3 specification, start here.
+ * [spdx-spec](./spdx-spec) - The canonical SPDX specification, such as website
+   files, RDF file, etc. This has both static content as well as content
+   generated from the SPDX 3 model Markdown files.
+ * [spec-parser](./spec-parser) - This is the tool that translates the SPDX 3
+   model files from Markdown to various outputs
+
+## Community
+
+These repositories are related to the SPDX Community activities
+
+ * [meetings](./meetings) - Information about SPDX meetings including schedule,
+   links to join, minutes, etc.
+ * [outreach](./outreach) - Outreach resources for SPDX (e.g. Conference talks,
+   presentations, etc.)


### PR DESCRIPTION
Adds a README for the SPDX Profile, which will be shown on the organization overview on GitHub