### PR TITLE
profile/README: Fix links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -10,51 +10,55 @@ categories below to find the repositories you are interested in.
 These repositories are useful if you are looking for more information about how
 to use SPDX and example SPDX files.
 
- * [using](./using) - This repository contains long-form text that explains how
-   to use SPDX, or walks readers through various SPDX use cases.
- * [spdx-examples](./spdx-examples) - This repository contains example SPDX
-   files covering various versions and use cases
-
+ * [using](https://github.com/spdx/using) - This repository contains long-form
+   text that explains how to use SPDX, or walks readers through various SPDX
+   use cases.
+ * [spdx-examples](https://github.com/spdx/spdx-examples) - This repository
+   contains example SPDX files covering various versions and use cases
 
 ## SPDX SBoM Tooling
 
 These repository contain SPDX related tools and code bindings, which are useful
 if you want to produce or consumer SPDX documents.
 
- * [tools-python](./tools-python) - Python library for dealing with SPDX
-   documents
- * [tools-golang](./tools-golang) - Go library for dealing with SPDX documents
- * [tools-java](./tools-java) - Java library for dealing with SPDX documents
- * [spdx-python-model](./spdx-python-model) - Low level Python library for
-   reading and writing SPDX documents
- * [spdx-go-model](./spdx-go-model) - Low level Go library for reading and
-   writing SPDX documents
+ * [tools-python](https://github.com/spdx/tools-python) - Python library for
+   dealing with SPDX documents
+ * [tools-golang](https://github.com/spdx/tools-golang) - Go library for
+   dealing with SPDX documents
+ * [tools-java](https://github.com/spdx/tools-java) - Java library for dealing
+   with SPDX documents
+ * [spdx-python-model](https://github.com/spdx/spdx-python-model) - Low level
+   Python library for reading and writing SPDX documents
+ * [spdx-go-model](https://github.com/spdx/spdx-go-model) - Low level Go
+   library for reading and writing SPDX documents
 
 ## SPDX Licenses
 
 These repositories are related to the SPDX License List
 
- * [license-list-XML](./license-list-XML) - The XML Source for the SPDX License List
- * [license-list-data](./license-list-data) - The generated content (e.g. Web
-   site, JSON, etc) from the License List XML
+ * [license-list-XML](https://github.com/spdx/license-list-XML) - The XML
+   Source for the SPDX License List
+ * [license-list-data](https://github.com/spdx/license-list-data) - The
+   generated content (e.g. Web site, JSON, etc) from the License List XML
 
 ## SPDX 3 SBoM Model
 
 These repositories define the SPDX 3 SBoM Standard
 
- * [spdx-3-model](./spdx-3-model) - This is the main SPDX 3 model files. If you
-   would like to modify or extend the SPDX 3 specification, start here.
- * [spdx-spec](./spdx-spec) - The canonical SPDX specification, such as website
-   files, RDF file, etc. This has both static content as well as content
-   generated from the SPDX 3 model Markdown files.
- * [spec-parser](./spec-parser) - This is the tool that translates the SPDX 3
-   model files from Markdown to various outputs
+ * [spdx-3-model](https://github.com/spdx/spdx-3-model) - This is the main SPDX
+   3 model files. If you would like to modify or extend the SPDX 3
+   specification, start here.
+ * [spdx-spec](https://github.com/spdx/spdx-spec) - The canonical SPDX
+   specification, such as website files, RDF file, etc. This has both static
+   content as well as content generated from the SPDX 3 model Markdown files.
+ * [spec-parser](https://github.com/spdx/spec-parser) - This is the tool that
+   translates the SPDX 3 model files from Markdown to various outputs
 
 ## Community
 
 These repositories are related to the SPDX Community activities
 
- * [meetings](./meetings) - Information about SPDX meetings including schedule,
-   links to join, minutes, etc.
- * [outreach](./outreach) - Outreach resources for SPDX (e.g. Conference talks,
-   presentations, etc.)
+ * [meetings](https://github.com/spdx/meetings) - Information about SPDX
+   meetings including schedule, links to join, minutes, etc.
+ * [outreach](https://github.com/spdx/outreach) - Outreach resources for SPDX
+   (e.g. Conference talks, presentations, etc.)


### PR DESCRIPTION
Fixes the links in the profile README. Relative links are not support so use full links