### PR TITLE
Add C++ binding, build tools, crypto algo list

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -20,7 +20,7 @@ to use SPDX and example SPDX files.
 
 These repositories contain SPDX related tools, language bindings,
 and dependency manager plugins, which are useful
-if you want to produce or consumer SPDX documents.
+if you want to produce or consume SPDX documents.
 
 ### Online tools
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -21,21 +21,25 @@ to use SPDX and example SPDX files.
 These repository contain SPDX related tools and code bindings, which are useful
 if you want to produce or consumer SPDX documents.
 
-#### Python
- * [tools-python](https://github.com/spdx/tools-python) - Python library for
-   dealing with SPDX documents
- * [spdx-python-model](https://github.com/spdx/spdx-python-model) - Low level
-   Python library for reading and writing SPDX documents
+### Online tools
+
  * [spdx-online-tools](https://github.com/spdx/spdx-online-tools) - Source for the [tools.spdx.org](https://tools.spdx.org/app/)
    web application
 
-#### Go
+### C++
+
+- [spdx-cpp-model](https://github.com/spdx/spdx-cpp-model) - Low level
+  C++ library for reading and writing SPDX documents
+
+### Go
+
  * [tools-golang](https://github.com/spdx/tools-golang) - Go library for
    dealing with SPDX documents
  * [spdx-go-model](https://github.com/spdx/spdx-go-model) - Low level Go
    library for reading and writing SPDX documents
 
-#### Java
+### Java
+
  * [tools-java](https://github.com/spdx/tools-java) - Java command line utility for managing
    and converting SPDX documents
  * [spdx-java-library](https://github.com/spdx/spdx-java-library) - Java library supporting
@@ -44,8 +48,16 @@ if you want to produce or consumer SPDX documents.
    Descriptions of these repos can be found in the
    [spdx-java-library API documentation](https://github.com/spdx/spdx-java-library?tab=readme-ov-file#api-documentation)
 
-#### JavaScript
+### JavaScript
+
  * [tools-ts](https://github.com/spdx/tools-ts) - TypeScript / JavaScript library for writing SPDX documents
+
+### Python
+
+- [tools-python](https://github.com/spdx/tools-python) - Python library for
+  dealing with SPDX documents
+- [spdx-python-model](https://github.com/spdx/spdx-python-model) - Low level
+  Python library for reading and writing SPDX documents
 
 ## SPDX Licenses
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -16,9 +16,10 @@ to use SPDX and example SPDX files.
  * [spdx-examples](https://github.com/spdx/spdx-examples) - This repository
    contains example SPDX files covering various versions and use cases
 
-## SPDX SBoM Tooling
+## SPDX SBOM tooling
 
-These repository contain SPDX related tools and code bindings, which are useful
+These repositories contain SPDX related tools, language bindings,
+and dependency manager plugins, which are useful
 if you want to produce or consumer SPDX documents.
 
 ### Online tools
@@ -26,19 +27,34 @@ if you want to produce or consumer SPDX documents.
  * [spdx-online-tools](https://github.com/spdx/spdx-online-tools) - Source for the [tools.spdx.org](https://tools.spdx.org/app/)
    web application
 
-### C++
+### Build and dependency management tools
+
+- [spdx-gradle-plugin](https://github.com/spdx/spdx-gradle-plugin) -
+  This plugin generates JSON formatted SPDX SBOMs for Gradle projects.
+- [spdx-maven-plugin](https://github.com/spdx/spdx-maven-plugin/) -
+  A plugin to Maven which produces SPDX documents for artifacts described in
+  the Maven POM file.
+- [rollup-plugin-spdx](https://github.com/spdx/rollup-plugin-spdx) -
+  When added to a Rollup configuration, this plugin will create an SBOM file
+  for the package that is being built.
+- [yarn-plugin-spdx](https://github.com/spdx/yarn-plugin-spdx) -
+  A Yarn plugin to create SBOM files in the SPDX format.
+
+### Language bindings
+
+#### C++
 
 - [spdx-cpp-model](https://github.com/spdx/spdx-cpp-model) - Low level
   C++ library for reading and writing SPDX documents
 
-### Go
+#### Go
 
  * [tools-golang](https://github.com/spdx/tools-golang) - Go library for
    dealing with SPDX documents
  * [spdx-go-model](https://github.com/spdx/spdx-go-model) - Low level Go
    library for reading and writing SPDX documents
 
-### Java
+#### Java
 
  * [tools-java](https://github.com/spdx/tools-java) - Java command line utility for managing
    and converting SPDX documents
@@ -48,26 +64,16 @@ if you want to produce or consumer SPDX documents.
    Descriptions of these repos can be found in the
    [spdx-java-library API documentation](https://github.com/spdx/spdx-java-library?tab=readme-ov-file#api-documentation)
 
-### JavaScript
+#### JavaScript
 
  * [tools-ts](https://github.com/spdx/tools-ts) - TypeScript / JavaScript library for writing SPDX documents
 
-### Python
+#### Python
 
 - [tools-python](https://github.com/spdx/tools-python) - Python library for
   dealing with SPDX documents
 - [spdx-python-model](https://github.com/spdx/spdx-python-model) - Low level
   Python library for reading and writing SPDX documents
-
-## SPDX Licenses
-
-These repositories are related to the SPDX License List
-
- * [license-list-XML](https://github.com/spdx/license-list-XML) - The XML
-   Source for the SPDX License List
- * [license-list-data](https://github.com/spdx/license-list-data) - The
-   generated content (e.g. Web site, JSON, etc) from the License List XML
- * [licenseListPublisher](https://github.com/spdx/LicenseListPublisher) - Source for the tool that generates the license list data
 
 ## SPDX 3 SBoM Model
 
@@ -83,6 +89,25 @@ These repositories define the SPDX 3 SBoM Standard
  * [spec-parser](https://github.com/spdx/spec-parser) - This is the tool that
    translates the SPDX 3 model files from Markdown to various outputs
 
+## SPDX License List
+
+These repositories are related to the SPDX License List
+
+- [license-list-XML](https://github.com/spdx/license-list-XML) -
+  The XML Source for the SPDX License List.
+- [license-list-data](https://github.com/spdx/license-list-data) -
+  The generated content (e.g. Web site, JSON, etc) from the License List XML.
+- [licenseListPublisher](https://github.com/spdx/LicenseListPublisher) -
+  Source for the tool that generates the license list data.
+
+## SPDX Cryptographic Algorithm List
+
+These repositories are related to the SPDX Cryptographic Algorithm List
+
+- [cryptographic-algorithm-list](https://github.com/spdx/cryptographic-algorithm-list) -
+  This repository contains the SPDX Cryptographic Algorithms List,
+  a standardized, community-curated list of cryptographic algorithms.
+
 ## Community
 
 These repositories are related to the SPDX Community activities
@@ -92,3 +117,5 @@ These repositories are related to the SPDX Community activities
  * [outreach](https://github.com/spdx/outreach) - Outreach resources for SPDX
    (e.g. Conference talks, presentations, etc.)
  * [governance](https://github.com/spdx/governance) - Governance practices for the SPDX Working Group.
+ * [GSoC](https://github.com/spdx/GSoC) -
+   SPDX participation in Google Summer of Code program.


### PR DESCRIPTION
- Add "Build and dependency management tools" subsection under "SPDX SBOM tooling"
- Add C++ to language bindings; sort language bindings by alphabetical order
- Add "SPDX Cryptographic Algorithm List" section
- Group SBOM headings and move "License List" to be next to "Cryptographic Algorithm List"
- Add "GSoC" (Google Summer of Code) to "Community" section

Most of them are from #7 